### PR TITLE
增加 google 流量统计功能

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,7 +21,7 @@ excerpt_link: more
 fancybox: true
 
 # Miscellaneous
-
+google_analytics: ''
 favicon: /favicon.png
 
 #你的头像

--- a/layout/_partial/google-analytics.ejs
+++ b/layout/_partial/google-analytics.ejs
@@ -1,0 +1,14 @@
+<% if (theme.google_analytics){ %>
+<!-- Google Analytics -->
+<script type="text/javascript">
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+ga('create', '<%= theme.google_analytics %>', 'auto');
+ga('send', 'pageview');
+
+</script>
+<!-- End Google Analytics -->
+<% } %>

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -29,5 +29,6 @@
     <link rel="icon" href="<%- theme.favicon %>">
   <% } %>
   <%- css('css/style') %>
+  <%- partial('google-analytics') %>
   <script src="http://libs.baidu.com/jquery/1.9.0/jquery.js"></script>
 </head>


### PR DESCRIPTION
在 HTML 文件头部添加 google analytics 脚本。用户只需要在_config.yml中指定tracking id，就可以在所有页面启用流量分析功能。
