### PR TITLE
Fix: #31. Add a space and an end symbol if the article is fully displaye...

### DIFF
--- a/layout/_partial/article.ejs
+++ b/layout/_partial/article.ejs
@@ -29,6 +29,13 @@
         </p>
       <% } else { %>
         <%- post.content %>
+        <% if (index){ %>
+          <!-- show an end symbol if the article is fully displayed -->
+          <hr/>
+          <p class="article-more-link">
+            <a>end</a>
+          </p>
+        <% } %>
       <% } %>
     </div>
     <% if (index){ %>


### PR DESCRIPTION
上一次 commit 没有解决 #31 的问题

![screenshot - 2_24_2015 9_33_55 am](https://cloud.githubusercontent.com/assets/3953067/6341848/8b752406-bc0a-11e4-9d25-148f5c22388d.png)

本次 commit 修补了这个问题

![screenshot - 2_24_2015 9_35_35 am](https://cloud.githubusercontent.com/assets/3953067/6341858/9dbcfc1a-bc0a-11e4-9ccb-f71662dd2274.png)
