### PR TITLE
问题#35代码块边框问题，#37行内代码换行问题

### DIFF
--- a/source/css/_partial/article.styl
+++ b/source/css/_partial/article.styl
@@ -76,6 +76,7 @@
     background: #ddd;
     border: 1px solid #ccc;
     font-family: Menlo,Monaco,"Andale Mono","lucida console","Courier New",monospace;
+	word-wrap: break-word;
   }
   blockquote {
     background: #ddd;

--- a/source/css/_partial/highlight.styl
+++ b/source/css/_partial/highlight.styl
@@ -31,6 +31,7 @@ $line-numbers
     background: color-background
     text-shadow: 0 1px #fff
     padding: 0 0.3em
+	border: none
   pre
     @extend $code-block
     code


### PR DESCRIPTION
#35 如果块级代码位于一个列表项内，代码会被加上边框；使用`border: none`清理
#37 行内代码过长会超过文章宽度；`word-wrap: break-word`自动换行