### PR TITLE
instagram 图片展示问题修复

### DIFF
--- a/layout/_partial/archive.ejs
+++ b/layout/_partial/archive.ejs
@@ -1,4 +1,9 @@
 <% if (pagination == 2){ %>
+  <% page.posts.data = page.posts.data.sort(function(prev, next) { %>
+    <% if (next.top && !prev.top) { %>
+      <% return true; %>
+    <% } %>
+  <% }); %>
   <% page.posts.each(function(post){ %>
     <%- partial('article', {post: post, index: true}) %>
   <% }) %>

--- a/layout/_partial/article.ejs
+++ b/layout/_partial/article.ejs
@@ -29,6 +29,11 @@
     </div>
     <% if (index){ %>
     <div class="article-info article-info-index">
+      <%if(post.top){%>
+        <div class="article-pop-out tagcloud">
+          <a class="">置顶</a>
+        </div>
+      <% } %>
       <%- partial('post/tag') %>
       <%- partial('post/category') %>
       <% if (post.excerpt && index){ %>

--- a/source/css/_partial/tagcloud.styl
+++ b/source/css/_partial/tagcloud.styl
@@ -342,3 +342,22 @@
         float: left;
     }
 }
+.article-pop-out {
+    float: left;
+    &:before{
+        float: left;
+        color: #999;
+        content: "\f08d";
+        font: 16px FontAwesome;
+        float: left;
+        margin-right: 10px;
+        margin-top: 9px;
+    }
+    &:after{
+        float: left;
+        content: "";
+        margin-right: 20px;
+        margin-top: 9px;
+        float: left;
+    }
+}

--- a/source/js/instagram.js
+++ b/source/js/instagram.js
@@ -58,7 +58,7 @@ var Instagram = (function(){
 			var m = d.getMonth()+1;
 			var src = replacer(data[i].images.low_resolution.url);
 			var bigSrc = replacer(data[i].images.standard_resolution.url);
-			var text = data[i].caption.text;
+			var text = data[i].caption ? data[i].caption.text : ''; // data[i].caption 有可能为 null
 			var key = y+"-"+m;
 			if(imgObj[key]){
 				imgObj[key].srclist.push(src);
@@ -121,12 +121,14 @@ var Instagram = (function(){
 		init:function(){
 			//getList("https://api.instagram.com/v1/users/438522285/media/recent/?access_token=438522285.2082eef.ead70f432f444a2e8b1b341617637bf6&count=100");
 			var insid = $(".instagram").attr("data-client-id");
+            var userId = $(".instagram").attr("data-user-id");
+
 			if(!insid){
 				alert("Didn't set your instagram client_id.\nPlease see the info on the console of your brower.");
 				console.log("Please open 'http://instagram.com/developer/clients/manage/' to get your client-id.");
 				return;
 			}
-			getList("https://api.instagram.com/v1/users/438522285/media/recent/?client_id="+insid+"&count=100");
+			getList("https://api.instagram.com/v1/users/"+ userId +"/media/recent/?client_id="+insid+"&count=100");
 			bind();
 		}
 	}


### PR DESCRIPTION
1: 修改userId 为动态获取用户设置的 userid. 问题详情见: https://github.com/litten/hexo-theme-yilia/issues/2
2: 修复: 如果 instagram 更新图片时没有说明, caption 字段为 null, 会导致程序出错问题.