### PR TITLE
文章页面增加了toc目录

### DIFF
--- a/layout/_partial/article.ejs
+++ b/layout/_partial/article.ejs
@@ -12,18 +12,31 @@
       <header class="article-header">
         <%- partial('post/title', {class_name: 'article-title'}) %>
       </header>
-      <% if (!index){ %>
-      <div class="article-info article-info-post">
-        <%- partial('post/tag') %>
-        <%- partial('post/category') %>
-        <div class="clearfix"></div>
-      </div>
+      <% if (!index){ %>        
+        <div class="article-info article-info-post">
+          <%- partial('post/tag') %>
+          <%- partial('post/category') %>
+          <div class="clearfix"></div>
+        </div>
       <% } %>
     <% } %>
     <div class="article-entry" itemprop="articleBody">
       <% if (post.excerpt && index){ %>
         <%- post.excerpt %>
       <% } else { %>
+        <% if (!index){ %>
+          <% if (toc(post.content)){ %>            
+            <div id="toc" class="article-toc">
+            <h2>目录</h2>
+              <%- toc(post.content) %>  
+            </div>
+            <script type="text/javascript">
+              var _article = document.getElementsByClassName('article')[0];
+              setTimeout("_article.style.marginRight = '211px'",0); 
+              setTimeout("document.getElementById('toc').style.right = '15px'", 0);                
+            </script>
+          <% } %>
+        <% } %>
         <%- post.content %>
       <% } %>
     </div>
@@ -75,6 +88,7 @@
       dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
       (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
     })();
+    $
   </script>
   <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
 </section>

--- a/layout/_partial/article.ejs
+++ b/layout/_partial/article.ejs
@@ -32,7 +32,8 @@
             </div>
             <script type="text/javascript">
               var _article = document.getElementsByClassName('article')[0];
-              setTimeout("_article.style.marginRight = '211px'",0); 
+              <!-- setTimeout("_article.style.marginRight = '211px'",0);  -->
+              setTimeout("_article.className += ' article2'",0); 
               setTimeout("document.getElementById('toc').style.right = '15px'", 0);                
             </script>
           <% } %>

--- a/source/css/_partial/article.styl
+++ b/source/css/_partial/article.styl
@@ -389,7 +389,10 @@
       }      
     }   
   }
-  
+  .article2{
+    margin-right: 211px;
+    transition: margin-right .5s ease-in;
+  }
 }
 
 

--- a/source/css/_partial/article.styl
+++ b/source/css/_partial/article.styl
@@ -6,7 +6,7 @@
   position: relative;
   border: 1px solid #ddd;
   background: #fff;
-  -webkit-transition: all 0.2s ease-in;
+  transition: all 0.2s ease-in;
   &.show{
     visibility: visible;
     -webkit-animation: cd-bounce-1 0.6s;
@@ -357,3 +357,39 @@
     float: right;
   }
 }
+
+@media (min-width: 1100px) { 
+  #toc{
+    /* display: none; */
+    background-color: #fff;
+    padding: 0 1em;
+    border:1px solid #ddd;
+    position: fixed;
+    top: 100px;
+    right: -180px;
+    transition: right .5s ease-in;
+    width: 150px;
+    h2{
+      margin-bottom:10px;
+    }
+    ol{
+      padding-left: 0!important;
+    }
+    line-height: 1.3em;
+    font-size: 0.8em;
+    float: right;
+    .toc{
+      padding: 0;
+      li{
+        list-style-type: none;
+        margin: .5em 0 .5em;
+        ol{
+          margin: .5em 0 .5em 1em;
+        }
+      }      
+    }   
+  }
+  
+}
+
+


### PR DESCRIPTION
移动端未添加，在浏览器宽度小于1100时，会隐藏toc目录，效果图
[普通效果](http://iblogc.com/2015/08/29/%E4%BD%BF%E7%94%A8synergy%E5%AE%9E%E7%8E%B0%E5%A4%9A%E5%8F%B0%E7%94%B5%E8%84%91%E5%85%B1%E4%BA%AB%E4%B8%80%E5%A5%97%E9%94%AE%E9%BC%A0/)
[目录名太长的效果，暂时没做优化](http://iblogc.com/2015/05/06/uc%E5%92%8Cqq%E6%B5%8F%E8%A7%88%E5%99%A8%E7%A7%81%E6%9C%89META/)
演示动态图（8.75M，慎入）：http://ww4.sinaimg.cn/large/704254f0gw1evyyrnrsuag21gk0quqvc.gif
![](http://ww4.sinaimg.cn/large/704254f0gw1evyyrnrsuag21gk0quqvc.gif)

