### PR TITLE
修复部分设备代码显示不完全的问题

### DIFF
--- a/source/css/_partial/highlight.styl
+++ b/source/css/_partial/highlight.styl
@@ -17,7 +17,6 @@ $code-block
   overflow: auto
   color: #4C4C4C
   line-height: font-size * line-height
-  border-radius: 4px
 
 $line-numbers
   color: #666
@@ -39,6 +38,7 @@ $line-numbers
       color: code-word
   .highlight
     @extend $code-block
+    border-radius: 4px
     pre
       border: none
       margin: 0

--- a/source/css/_partial/highlight.styl
+++ b/source/css/_partial/highlight.styl
@@ -5,7 +5,7 @@ code-tag = #F92672
 code-attr = #A6E22E
 code-word = #FFFFFF
 code-value = #E6DB74
-code-number = #7163D7
+code-number = #9E90FF
 code-keyword = #66D9EF
 code-comment = #75715E
 code-argument = #FD971F
@@ -118,6 +118,7 @@ pre
   .doctype
   .params
   .function
+  .css .value
     color: code-word
 
   .css ~ * .tag

--- a/source/css/_partial/main.styl
+++ b/source/css/_partial/main.styl
@@ -134,7 +134,7 @@
 		cursor: pointer;
 		text-transform: uppercase;
 		float:none;
-		height: 150px;
+		min-height: 150px;
 		margin-left: -12px;
 		text-align: center;
 		display: -webkit-box;


### PR DESCRIPTION
修复了iOS下safari由于`border-radius`的BUG导致代码显示不完全的问题,
更改`nav.header-menu`的`height`为`min-height`(写成height的话分组创建太多会有一部分无法显示)
更改部分`css模式`的高亮配色