### PR TITLE
修复移动端关闭动画后不显示头像bug,更新mobile-nav.ejs文件

### DIFF
--- a/layout/_partial/mobile-nav.ejs
+++ b/layout/_partial/mobile-nav.ejs
@@ -6,7 +6,11 @@
 	<div class="intrude-less">
 		<header id="header" class="inner">
 			<div class="profilepic">
+			<% if (theme.animate){ %>
 				<img lazy-src="<%=theme.avatar%>" class="js-avatar">
+			<%}else{%>
+				<img src="<%=theme.avatar%>" class="js-avatar" style="width: 100%;height: 100%;opacity: 1;">
+			<%}%>
 			</div>
 			<hgroup>
 			  <h1 class="header-author"><%=theme.author%></h1>


### PR DESCRIPTION
关闭动画以后，移动端显示的时候，头像会消失，改下themes\yilia\layout\_partial\mobile-nav.ejs文件，将如下代码：

<img lazy-src="<%=theme.avatar%>" class="js-avatar">

替换成：

<% if (theme.animate){ %>
<img lazy-src="<%=theme.avatar%>" class="js-avatar">
<%}else{%>
<img src="<%=theme.avatar%>" class="js-avatar" style="width: 100%;height: 100%;opacity: 1;">
<%}%>