### PR TITLE
修复"分享"部分显示问题

### DIFF
--- a/layout/_partial/post/share_jia.ejs
+++ b/layout/_partial/post/share_jia.ejs
@@ -1,11 +1,12 @@
-<div class="share_jia">
+<div class="share_jia"
+  style="padding-left:3%">
 	<!-- JiaThis Button BEGIN -->
 	<div class="jiathis_style">
 		<span class="jiathis_txt"><%= __('post.share') %>: &nbsp; </span>
 		<a class="jiathis_button_facebook"></a> 
-    <a class="jiathis_button_twitter"></a>
-    <a class="jiathis_button_plus"></a> 
-    <a class="jiathis_button_tsina"></a>
+    		<a class="jiathis_button_twitter"></a>
+    		<a class="jiathis_button_plus"></a> 
+    		<a class="jiathis_button_tsina"></a>
 		<a class="jiathis_button_cqq"></a>
 		<a class="jiathis_button_douban"></a>
 		<a class="jiathis_button_weixin"></a>


### PR DESCRIPTION
"分享"按钮部分没有对齐, 加入 style="padding-left:3%", 使得"分享"按钮部分和下面多说评论框对齐