### PR TITLE
解决左侧header-menu块居中在firefox中不兼容的问题

### DIFF
--- a/source/css/_partial/main.styl
+++ b/source/css/_partial/main.styl
@@ -138,6 +138,9 @@
 		margin-left: -12px;
 		text-align: center;
 		display: -webkit-box;
+		-moz-box-orient: horizontal;
+		-moz-box-pack: center;
+		-moz-box-align: center;
 		-webkit-box-orient: horizontal;
 		-webkit-box-pack: center;
 		-webkit-box-align: center;


### PR DESCRIPTION
[#183](https://github.com/litten/hexo-theme-yilia/issues/183)
