### PR TITLE
Update main.js

### DIFF
--- a/source/js/main.js
+++ b/source/js/main.js
@@ -62,7 +62,9 @@ require([], function (){
 				for(var i=0,len=imgArr.length;i<len;i++){
 					var src = imgArr.eq(i).attr("src");
 					var title = imgArr.eq(i).attr("alt");
-					imgArr.eq(i).replaceWith("<a href='"+src+"' title='"+title+"' rel='fancy-group' class='fancy-ctn fancybox'><img src='"+src+"' title='"+title+"'></a>");
+					var width = imgArr.eq(i).attr("width");
+					var height = imgArr.eq(i).attr("height");
+					imgArr.eq(i).replaceWith("<a href='"+src+"' title='"+title+"' rel='fancy-group' class='fancy-ctn fancybox'><img src='"+src+"' width="+width+" height="+height+" title='"+title+"'></a>");
 				}
 				$(".article-inner .fancy-ctn").fancybox();
 			}


### PR DESCRIPTION
解决在启用 fancybox 时，不能在文章中用 img 标签自定义图片大小的问题。