### PR TITLE
修复sidebar内容居中问题

### DIFF
--- a/source/css/_partial/main.styl
+++ b/source/css/_partial/main.styl
@@ -135,7 +135,6 @@
 		text-transform: uppercase;
 		float:none;
 		min-height: 150px;
-		margin-left: -12px;
 		text-align: center;
 		display: -webkit-box;
 		-webkit-box-orient: horizontal;
@@ -168,7 +167,6 @@
 		position: absolute;
 		transition: transform .3s ease-in;
 		.social {
-			margin-right:15px;
 			margin-top:10px;
 			text-align: center;
 			a {
@@ -188,9 +186,6 @@
 				&:hover {
 					opacity:1
 				}
-			}
-			a:last-of-type {
-				margin-right:0
 			}
 			a.weibo {
 				background:url('/img/weibo.png') center no-repeat #aaaaff;

--- a/source/css/_partial/tagcloud.styl
+++ b/source/css/_partial/tagcloud.styl
@@ -1,5 +1,5 @@
 .switch-btn {
-    margin-left: 74px;
+    margin-left: 79px;
     margin-top: 23px;
     position: relative; 
     width: 70px;


### PR DESCRIPTION
在自定义tips-inner的样式时，发现它的定位总是有些不准，经检查发现其父div的margin-left值设的有些问题，经计算修复为正确的值，顺便将main.styl的与之相关的黑魔法去掉了