### PR TITLE
不使用根目录时头像和blog author的链接指向问题

### DIFF
--- a/layout/_partial/left-col.ejs
+++ b/layout/_partial/left-col.ejs
@@ -2,11 +2,11 @@
 <div class="overlay" style="background: <%= theme.style && theme.style.header ? theme.style.header : defaultBg %>"></div>
 <div class="intrude-less">
 	<header id="header" class="inner">
-		<a href="/" class="profilepic">
+		<a href="<%=theme.root%>" class="profilepic">
 			<img src="<%=theme.avatar%>" class="js-avatar">
 		</a>
 		<hgroup>
-		  <h1 class="header-author"><a href="/"><%=theme.author%></a></h1>
+		  <h1 class="header-author"><a href=""<%=theme.root%>""><%=theme.author%></a></h1>
 		</hgroup>
 		<% if (theme.subtitle){ %>
 		<p class="header-subtitle"><%=theme.subtitle%></p>


### PR DESCRIPTION
当把博客部署在github page上时，由于没有使用根目录，点击头像和作者名称会出现404页面。