### PR TITLE
文章时间如果为今天则显示“今天”

### DIFF
--- a/layout/_partial/post/date.ejs
+++ b/layout/_partial/post/date.ejs
@@ -1,3 +1,11 @@
 <a href="<%- url_for(post.path) %>" class="<%= class_name %>">
-  	<time datetime="<%= date_xml(post.date) %>" itemprop="datePublished"><i class="icon-calendar icon"></i><%= date(post.date, date_format) %></time>
+  	<time datetime="<%= date_xml(post.date) %>" itemprop="datePublished">
+  		<i class="icon-calendar icon"></i>
+  		<% var today = date(post.date, date_format); %>
+  		<% if( today == date(new Date, date_format) ){ %>
+  		<%- "今天"   %>
+  		<% }else{ %>
+  		<%-	 today  %>
+  		<% } %>
+  	</time>
 </a>


### PR DESCRIPTION
人眼对数字日期的敏感度较低，一般博主会比较期望最新的文章受读者关注，所以建议把当天的文章的时间显示为“今天”，而不是日期字符串。如：

![1](https://cloud.githubusercontent.com/assets/25657710/24533717/11f3c328-15fc-11e7-966c-c93f4c2feb65.png)
