### PR TITLE
Update left-col.ejs 更新avatar和author的链接路径

### DIFF
--- a/layout/_partial/left-col.ejs
+++ b/layout/_partial/left-col.ejs
@@ -2,11 +2,11 @@
 <div class="overlay" style="background: <%= theme.style && theme.style.header ? theme.style.header : defaultBg %>"></div>
 <div class="intrude-less">
 	<header id="header" class="inner">
-		<a href="/" class="profilepic">
+		<a href="<%=theme.root%>" class="profilepic">
 			<img src="<%=theme.avatar%>" class="js-avatar">
 		</a>
 		<hgroup>
-		  <h1 class="header-author"><a href="/"><%=theme.author%></a></h1>
+		  <h1 class="header-author"><a href="<%=theme.root%>"><%=theme.author%></a></h1>
 		</hgroup>
 		<% if (theme.subtitle){ %>
 		<p class="header-subtitle"><%=theme.subtitle%></p>


### PR DESCRIPTION
原来的avatar和author的链接路径写死为／，导致链接会固定跳转到XXX.github.io；
如果root有设置，举例/blog/，链接会跳出当前blog，导致出错。
解决： 增加root的判断，将href="/" 改为 href="<%=theme.root%>"