### PR TITLE
数学公式MathJax的CDN地址已经改变，原地址已不再能够访问

### DIFF
--- a/layout/_partial/mathjax.ejs
+++ b/layout/_partial/mathjax.ejs
@@ -15,5 +15,5 @@ MathJax.Hub.Queue(function() {
 });
 </script>
 
-<script src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+<script src="//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>


### PR DESCRIPTION
根据MathJax CDN的政策
原有的CDN地址已不再有效
切换成另外的CDN地址了
对原有的MathJax-CDN进行了地址的替换，已可以正常工作
官网信息链接：https://www.mathjax.org/cdn-shutting-down/
![image](https://user-images.githubusercontent.com/17025439/35660160-79254a7c-0745-11e8-94a0-5eda551e8f02.png)
