### PR TITLE
fix: 修复post的分类链接结尾的/重复

### DIFF
--- a/layout/_partial/post/category.ejs
+++ b/layout/_partial/post/category.ejs
@@ -4,7 +4,7 @@
 		<ul class="article-tag-list">
 			<% post.categories.forEach(function(tag, i){ %> 
         		<li class="article-tag-list-item">
-        			<a href="<%= config.root %><%= tag.path %>/" class="article-tag-list-link color<%= tag.name.length % 5 + 1 %>"><%-tag.name%></a>
+        			<a href="<%= config.root %><%= tag.path %>" class="article-tag-list-link color<%= tag.name.length % 5 + 1 %>"><%-tag.name%></a>
         		</li>
       		<% }) %>
 		</ul>


### PR DESCRIPTION

分类链接`categories/categoryName//` 结尾多了一个`/`