### PR TITLE
Patch comment

### DIFF
--- a/layout/_partial/article.ejs
+++ b/layout/_partial/article.ejs
@@ -84,7 +84,7 @@
   <%- partial('post/duoshuo', {
       key: post.slug,
       title: post.title,
-      url: config.url+url_for(post.path)
+      url: post.permalink
     }) %>
   <% } %>
   
@@ -92,7 +92,7 @@
   <%- partial('post/wangyiyun', {
       key: post.slug,
       title: post.title,
-      url: config.url+url_for(post.path)
+      url: post.permalink
     }) %>
   <% } %>
 
@@ -100,7 +100,7 @@
   <%- partial('post/changyan', {
       key: post.slug,
       title: post.title,
-      url: config.url+url_for(post.path)
+      url: post.permalink
     }) %>
   <% } %>
 
@@ -126,7 +126,7 @@
   <%- partial('post/gitment', {
       key: post.slug,
       title: post.title,
-      url: config.url+url_for(post.path)
+      url: post.permalink
     }) %>
   <% } %>
 <% } %>

--- a/layout/_partial/article.ejs
+++ b/layout/_partial/article.ejs
@@ -105,21 +105,11 @@
   <% } %>
 
   <% if (theme.disqus || config.disqus_shortname){ %>
-    <section id="comments">
-      <div id="disqus_thread"></div>
-        <script type="text/javascript">
-        /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
-        var disqus_shortname = '<%= theme.disqus || config.disqus_shortname %>'; // required: replace example with your forum shortname
-
-        /* * * DON'T EDIT BELOW THIS LINE * * */
-        (function() {
-          var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-          dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
-          (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-        })();
-      </script>
-      <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
-    </section>
+  <%- partial('post/disqus', {
+      key: post.slug,
+      title: post.title,
+      url: post.permalink
+    }) %>
   <% } %>
 
   <% if (theme.gitment_owner && theme.gitment_repo &&theme.gitment_oauth && theme.gitment_oauth.client_id && theme.gitment_oauth.client_secret){ %>

--- a/layout/_partial/post/disqus.ejs
+++ b/layout/_partial/post/disqus.ejs
@@ -1,0 +1,21 @@
+<section id="comments">
+  <div id="disqus_thread"></div>
+	<script>
+	var disqus_shortname = '<%= theme.disqus || config.disqus_shortname %>';
+
+	var disqus_config = function () {
+	this.page.identifier = '<%=key%>';
+	this.page.title = '<%=title%>';
+	this.page.url = '<%=url%>'; 
+	};
+	
+	(function() {
+	var d = document, s = d.createElement('script');
+	s.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
+	s.async = true;
+	s.setAttribute('data-timestamp', +new Date());
+	(d.head || d.body).appendChild(s);
+	})();
+  </script>
+  <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+</section>


### PR DESCRIPTION
1. fix: 评论传入的url错误

url_for()生成的是当前页面跳转到参数path的相对路径，不能用来直接拼接完整url。
如：
+ 当前页面是/post/xxx，`url_for('/post/aaa')`的返回值就会是aaa
直接拿来拼接就会产生`http://host/aaa`的错误链接
+ 当前页面是/post/xxx，`url_for('/post/xxx')`的返回值就会是空字符串
直接拿来拼接就会产生`http://host/`的错误链接

应当使用permallink属性得到完整url

2. 分离disqus到独立文件
与支持的其他评论系统一样单独成文件，模块化