### PR TITLE
Fixed "validation error" caused by long url of a post

### DIFF
--- a/layout/_partial/post/gitment.ejs
+++ b/layout/_partial/post/gitment.ejs
@@ -3,7 +3,7 @@
 <script src="//imsun.github.io/gitment/dist/gitment.browser.js"></script>
 <script>
 var gitment = new Gitment({
-  id: "<%=url%>",
+  id: "<%=page.date%>",
   owner: '<%=theme.gitment_owner%>',
   repo: '<%=theme.gitment_repo%>',
   oauth: {


### PR DESCRIPTION
Avoiding "Validation error" caused by a too long url of a post.

FYI, the idea belongs to @iHTCboy and for more information please click [here](https://github.com/imsun/gitment/issues/112)