### PR TITLE
对share.ejs文件进行更新，原先二维码生成已失效。建议修改此地址

### DIFF
--- a/layout/_partial/post/share.ejs
+++ b/layout/_partial/post/share.ejs
@@ -46,7 +46,7 @@
     <a class="close js-modal-close" href="javascript:;"><i class="icon icon-close"></i></a>
     <p>扫一扫，分享到微信</p>
     <div class="wx-qrcode">
-      <img src="<%- 'qrcode' in locals ? qrcode(sUrl) : '//pan.baidu.com/share/qrcode?url=' + sUrl  %>" alt="微信分享二维码">
+      <img src="<%- 'qrcode' in locals ? qrcode(sUrl) : 'http://bshare.optimix.asia/barCode?site=weixin&url=' + sUrl  %>" alt="微信分享二维码">
     </div>
 </div>
 


### PR DESCRIPTION
> 一开始感觉可能是自己代码没有整理清楚的问题导致，后来发现大部分的小伙伴都出现微信二维码失效的问题。

顺便说下，很崇拜**Litten**